### PR TITLE
Fix issue with prisma:migrate:dev

### DIFF
--- a/.env example
+++ b/.env example
@@ -11,3 +11,7 @@ MONAD_GUILD_ID=MONAD_GUILD_ID_here
 
 # POSTGRES
 DATABASE_URL=your_postgres_url_here
+
+# SUPABASE (Optional)
+# Only needed if you're using Supabase instead of a local Postgres instance
+DIRECT_URL=your_supabase_direct_url_here

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1,6 +1,8 @@
 datasource db {
   provider = "postgresql"
   url      = env("DATABASE_URL")
+  directUrl = env("DIRECT_URL")
+
 }
 
 generator client {


### PR DESCRIPTION

This PR addresses the database connection issue by adding a direct URL to the Prisma schema and environment configuration. Supabase requires this direct URL for proper database connectivity.

Changes
- Added `directUrl` to the Prisma schema file
- Updated `.env` file to include the `DIRECT_URL` variable
- Updated `.env.example` to reflect the new environment variable

 How to Test
1. Update your local `.env` file with the `DIRECT_URL` from Supabase
2. Run database migrations
3. Verify successful database migrations

 Fixes this #1 
