### PR TITLE
chore: disabled react-in-jsx-scope lint rule

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -12,5 +12,7 @@
     "ecmaVersion": 2021,
     "sourceType": "module"
   },
-  "rules": {}
+  "rules": {
+    "react/react-in-jsx-scope": "off"
+  }
 }

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -5,14 +5,13 @@
     "eslint:recommended",
     "plugin:react/recommended",
     "plugin:@typescript-eslint/recommended",
-    "prettier"
+    "prettier",
+    "plugin:react/jsx-runtime"
   ],
   "plugins": ["react", "@typescript-eslint"],
   "parserOptions": {
     "ecmaVersion": 2021,
     "sourceType": "module"
   },
-  "rules": {
-    "react/react-in-jsx-scope": "off"
-  }
+  "rules": {}
 }


### PR DESCRIPTION
Disabled `react/react-in-jsx-scope` rule since nextjs already support new compiler from [Next.js v9.5.3+](https://legacy.reactjs.org/blog/2020/09/22/introducing-the-new-jsx-transform.html#nextjs). This rule [is no longer valid post React v17
](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/react-in-jsx-scope.md#when-not-to-use-it)